### PR TITLE
docs: fix typo in composable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Validate a GitHub webhook in a server API route.
 
 ```js
 export default defineEventHandler(async (event) => {
-  const isValidWebhook = await isValidGitHubWebhook(event)
+  const isValidWebhook = await isValidGithubWebhook(event)
 
   if (!isValidWebhook) {
     throw createError({ statusCode: 401, message: 'Unauthorized: webhook is not valid' })


### PR DESCRIPTION
to be honest it would be better if we renamed the composable to `isValidGitHubWebhook` (with maybe a duplicate of `isValidGithubWebhook` for backwards compatibility), but just wanted to update the docs to reflect the name that's currently used before I forgot