### PR TITLE
refactor: rename `isValidGithubWebhook` to `isValidGitHubWebhook`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Validate a GitHub webhook in a server API route.
 
 ```js
 export default defineEventHandler(async (event) => {
-  const isValidWebhook = await isValidGithubWebhook(event)
+  const isValidWebhook = await isValidGitHubWebhook(event)
 
   if (!isValidWebhook) {
     throw createError({ statusCode: 401, message: 'Unauthorized: webhook is not valid' })

--- a/playground/server/api/webhooks/github.post.ts
+++ b/playground/server/api/webhooks/github.post.ts
@@ -1,5 +1,5 @@
 export default defineEventHandler(async (event) => {
-  const isValidWebhook = await isValidGithubWebhook(event)
+  const isValidWebhook = await isValidGitHubWebhook(event)
 
   if (!isValidWebhook) throw createError({ statusCode: 401, message: 'Unauthorized: webhook is not valid' })
 

--- a/src/runtime/server/lib/validators/github.ts
+++ b/src/runtime/server/lib/validators/github.ts
@@ -9,7 +9,7 @@ const GITHUB_SIGNATURE = 'X-Hub-Signature-256'.toLowerCase()
  * @param event H3Event
  * @returns {boolean} `true` if the webhook is valid, `false` otherwise
  */
-export const isValidGithubWebhook = async (event: H3Event): Promise<boolean> => {
+export const isValidGitHubWebhook = async (event: H3Event): Promise<boolean> => {
   const config = ensureConfiguration('github', event)
 
   const headers = getRequestHeaders(event)
@@ -25,3 +25,9 @@ export const isValidGithubWebhook = async (event: H3Event): Promise<boolean> => 
   const computedHash = await computeSignature(config.secretKey, HMAC_SHA256, body)
   return computedHash === webhookSignature
 }
+
+/**
+ * Alias for backwards compatibility
+ * @deprecated Use `isValidGitHubWebhook` instead
+ */
+export const isValidGithubWebhook = (event: H3Event): Promise<boolean> => isValidGitHubWebhook(event)

--- a/src/runtime/server/lib/validators/github.ts
+++ b/src/runtime/server/lib/validators/github.ts
@@ -30,4 +30,4 @@ export const isValidGitHubWebhook = async (event: H3Event): Promise<boolean> => 
  * Alias for backwards compatibility
  * @deprecated Use `isValidGitHubWebhook` instead
  */
-export const isValidGithubWebhook = (event: H3Event): Promise<boolean> => isValidGitHubWebhook(event)
+export const isValidGithubWebhook = (event: H3Event) => isValidGitHubWebhook(event)

--- a/test/events.ts
+++ b/test/events.ts
@@ -1,5 +1,5 @@
 export { simulateDiscordEvent } from './simulations/discord'
-export { simulateGithubEvent } from './simulations/github'
+export { simulateGitHubEvent } from './simulations/github'
 export { simulateHerokuEvent } from './simulations/heroku'
 export { simulatePaddleEvent } from './simulations/paddle'
 export { simulateTwitchEvent } from './simulations/twitch'

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -47,7 +47,7 @@ describe('webhooks', () => {
   })
 
   it('valid GitHub webhook', async () => {
-    const response = await events.simulateGithubEvent()
+    const response = await events.simulateGitHubEvent()
     expect(response).toStrictEqual(validWebhook)
   })
 

--- a/test/simulations/github.ts
+++ b/test/simulations/github.ts
@@ -7,7 +7,7 @@ import nuxtConfig from '../fixtures/basic/nuxt.config'
 const body = 'testBody'
 const secretKey = nuxtConfig.runtimeConfig?.webhook?.github?.secretKey
 
-export const simulateGithubEvent = async () => {
+export const simulateGitHubEvent = async () => {
   const signature = await subtle.importKey('raw', encoder.encode(secretKey), HMAC_SHA256, false, ['sign'])
   const hmac = await subtle.sign(HMAC_SHA256.name, signature, encoder.encode(body))
   const computedHash = Buffer.from(hmac).toString('hex')


### PR DESCRIPTION
Thanks to Daniel for suggesting the change in #4 

- [x] Renamed `isValidGithubWebhook` composable to `isValidGitHubWebhook`
- [x] Updated docs
- [x] Updated playground
- [x] Renamed GitHub test method to keep the same format